### PR TITLE
Allow ssh keys in users

### DIFF
--- a/recipes/chroot_users.rb
+++ b/recipes/chroot_users.rb
@@ -37,8 +37,10 @@ data_bag(:users).each do |user|
       owner user_item['id']
     end
 
-    directory File.join(home, '.ssh') do
-      action :delete
+    unless user_item['ssh_keys']
+      directory File.join(home, '.ssh') do
+        action :delete
+      end
     end
   end
 end

--- a/test/integration/data_bags/users/sftpuser.json
+++ b/test/integration/data_bags/users/sftpuser.json
@@ -1,7 +1,7 @@
 {
   "id": "sftpuser",
   "password": "$1$9ZrtGbLX$jBnUY3Ptg6YljtFbb7/Gp.",
-  "ssh_keys": "AAAAB3NzaC1yc2EAAAABIwAAAIEA1on8gxCGJJWSRT4uOrR13mUaUk0hRf4RzxSZ1zRbYYFw8pfGesIFoEuVth4HKyF8k1y4mRUnYHP1XNMNMJl1JcEArC2asV8sHf6zSPVffozZ5TT4SfsUu/iKy9lUcCfXzwre4WWZSXXcPff+EHtWshahu3WzBdnGxm5Xoi89zcE=",
+  "ssh_keys": "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAIEA1on8gxCGJJWSRT4uOrR13mUaUk0hRf4RzxSZ1zRbYYFw8pfGesIFoEuVth4HKyF8k1y4mRUnYHP1XNMNMJl1JcEArC2asV8sHf6zSPVffozZ5TT4SfsUu/iKy9lUcCfXzwre4WWZSXXcPff+EHtWshahu3WzB dummykey@example.com",
   "groups": ["sftp"],
   "shell": "/bin/false"
 }

--- a/test/integration/data_bags/users/sftpuser.json
+++ b/test/integration/data_bags/users/sftpuser.json
@@ -1,6 +1,7 @@
 {
   "id": "sftpuser",
   "password": "$1$9ZrtGbLX$jBnUY3Ptg6YljtFbb7/Gp.",
+  "ssh_keys": "AAAAB3NzaC1yc2EAAAABIwAAAIEA1on8gxCGJJWSRT4uOrR13mUaUk0hRf4RzxSZ1zRbYYFw8pfGesIFoEuVth4HKyF8k1y4mRUnYHP1XNMNMJl1JcEArC2asV8sHf6zSPVffozZ5TT4SfsUu/iKy9lUcCfXzwre4WWZSXXcPff+EHtWshahu3WzBdnGxm5Xoi89zcE=",
   "groups": ["sftp"],
   "shell": "/bin/false"
 }

--- a/test/integration/default/serverspec/localhost/users_spec.rb
+++ b/test/integration/default/serverspec/localhost/users_spec.rb
@@ -33,7 +33,10 @@ describe group('sftp') do
   it { should exist }
 end
 
-# Not currently testable...
-#describe file('/home/sftpuser/.ssh') do
-#  it { should_not exist }
-#end
+describe file('/home/sftpuser/.ssh/') do
+  it { should be_directory }
+end
+
+describe file('/home/sftpuser/.ssh/authorized_keys') do
+  it { should be_file }
+end


### PR DESCRIPTION
This PR allows to have ssh public keys as supported by users cookbook as sftp users.

A condition has been added in order to avoid deleting .ssh/ directory when there is ssh_keys present in the users data bag.

A couple of tests has been added that ensure the .ssh directory and authorized_keys are present, these adjustments in the test suite could make it incompatible when testing the case of passwords (and then deleting the .ssh directory), but right as the databag is changed now, all tests pass.

